### PR TITLE
hotfix/loc 549 prevent permissions request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Version 2.0.0 March 1, 2023
+===============================
+# Changed:
+- Prevent Gimbal from requesting location permissions automatically
+- Airship version from 16.10.7 -> 16.11.1
+
+
 Version 1.1.0 January 31, 2023
 ===============================
 # Fixed:

--- a/GimbalAirshipAdapter.podspec
+++ b/GimbalAirshipAdapter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files            = "Pod/Classes/*"
   s.requires_arc            = true
   s.dependency                "GimbalXCFramework", "~> 2.93"
-  s.dependency                "Airship", "~> 16.10.7"
+  s.dependency                "Airship", "~> 16.11.1"
   s.pod_target_xcconfig = {
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386'
   }

--- a/GimbalAirshipAdapter.podspec
+++ b/GimbalAirshipAdapter.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-  s.version                 = "1.1.1"
+  s.version                 = "2.0.0"
   s.name                    = "GimbalAirshipAdapter"
   s.summary                 = "An adapter for integrating Gimbal place events with Airship."
   s.documentation_url       = "https://github.com/gimbalinc/airship-adapter-ios"

--- a/Pod/Classes/GimbalAirshipAdapter.swift
+++ b/Pod/Classes/GimbalAirshipAdapter.swift
@@ -137,7 +137,7 @@ fileprivate let defaultsSuiteName = "arshp_gmbl_def_suite"
             return
         }
 
-        Gimbal.setAPIKey(key, options: nil)
+        Gimbal.setAPIKey(key, options: ["MANAGE_PERMISSIONS" : false])
         Gimbal.start()
         updateDeviceAttributes()
         print("Started Gimbal Adapter. Gimbal application instance identifier: \(Gimbal.applicationInstanceIdentifier() ?? "⚠️ Empty Gimbal application instance identifier")")


### PR DESCRIPTION
This PR disables the automatic location permissions request and bumps the Airship pod version to the latest.