### PR TITLE
Refactor 'restore' and update changelog.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Unreleased
+===============================
+# Changed:
+- 'restore()' now starts the adapter, if the adapter was previously started
+- 'restore()' is now called upon adapter initialization
+
+
 Version 2.0.0 March 1, 2023
 ===============================
 # Changed:

--- a/GimbalAirshipAdapter.podspec
+++ b/GimbalAirshipAdapter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files            = "Pod/Classes/*"
   s.requires_arc            = true
   s.dependency                "GimbalXCFramework", "~> 2.93"
-  s.dependency                "Airship", "~> 16.11.1"
+  s.dependency                "Airship", "~> 16.10"
   s.pod_target_xcconfig = {
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386'
   }

--- a/Pod/Classes/GimbalAirshipAdapter.swift
+++ b/Pod/Classes/GimbalAirshipAdapter.swift
@@ -114,7 +114,6 @@ fileprivate let defaultsSuiteName = "arshp_gmbl_def_suite"
         if (defaults.value(forKey: hideBlueToothAlertViewKey) == nil) {
             defaults.set(true, forKey: hideBlueToothAlertViewKey)
         }
-        self.restore()
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(AirshipAdapter.updateDeviceAttributes),


### PR DESCRIPTION
This PR refactors the `restore` method so that it starts the adapter if it was started in a previous session. Also, `restore` is now called upon adapter initialization.